### PR TITLE
Generate imports for protobuf dependencies

### DIFF
--- a/protoc-gen-jsonpb_haskell/main.go
+++ b/protoc-gen-jsonpb_haskell/main.go
@@ -73,6 +73,10 @@ func (g *generator) generateHaskellCode(file *descriptor.FileDescriptorProto) st
 	print(b, "import qualified Data.Text as T")
 	print(b, "")
 
+  for _, dep := range file.Dependency {
+      print(b, "import           Proto.%s_JSON ()", packageType(dep))
+  }
+
 	print(b, "import           Proto.%s as P", moduleName)
 	print(b, "import           Proto.%s_Fields as P", moduleName)
 


### PR DESCRIPTION
This is similar to to the change I made in [twirp_haskell#25](https://github.com/tclem/twirp-haskell/pull/25). I haven't needed it until now because my common protobuf file didn't define anything that was needed for the parent's JSONPB. Now, I have a shared enum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tclem/proto-lens-jsonpb/9)
<!-- Reviewable:end -->
