### PR TITLE
Fix the module name of JSON module.

### DIFF
--- a/protoc-gen-jsonpb_haskell/main.go
+++ b/protoc-gen-jsonpb_haskell/main.go
@@ -56,7 +56,7 @@ func (g *generator) generateHaskellCode(file *descriptor.FileDescriptorProto) st
 	print(b, "{-# LANGUAGE OverloadedStrings #-}")
 	print(b, "{-# OPTIONS_GHC -Wno-orphans -Wno-unused-imports -Wno-missing-export-lists #-}")
 
-	moduleName := packageFileName(filePath(file))
+	moduleName := toModuleName(file)
 	print(b, "module Proto.%s_JSON where", moduleName)
 	print(b, "")
 


### PR DESCRIPTION
When there's subfolders, like:
`proto/google/protobuf/any.proto`
Currently, the generated module name is `Proto.Google/Protobuf/Empty_JSON`, but the expected should be `Proto.Google.Protobuf.Empty_JSON`